### PR TITLE
feat(planet/nixos/persistence, planet/hm/persistence): use bind mounts instead of `bindfs` for user directories

### DIFF
--- a/home-manager/users/shiba/default.nix
+++ b/home-manager/users/shiba/default.nix
@@ -24,6 +24,7 @@
   planet = {
     persistence = {
       enable = true;
+      useBindMounts = true;
       persistXdgUserDirectories = true;
       directories = [
         "Sync"

--- a/home-manager/users/shiba/sops/default.nix
+++ b/home-manager/users/shiba/sops/default.nix
@@ -7,7 +7,7 @@
     localFlakeInputs.sops-nix.homeManagerModules.sops
   ];
 
-  home.persistence."/persist/home/shiba" = {
+  planet.persistence = {
     directories = [
       ".config/sops"
     ];

--- a/planet/modules/home-manager/gtk/default.nix
+++ b/planet/modules/home-manager/gtk/default.nix
@@ -42,6 +42,13 @@
           };
           name = "Papirus-Dark";
         };
+        gtk3.bookmarks = builtins.map (dir: "file://" + config.home.homeDirectory + "/" + dir) [
+          "Documents"
+          "Downloads"
+          "Music"
+          "Pictures"
+          "Videos"
+        ];
       };
     };
 }

--- a/planet/modules/nixos/persistence/default.nix
+++ b/planet/modules/nixos/persistence/default.nix
@@ -104,11 +104,22 @@
     let
       cfg = config.planet.persistence;
       inherit (lib) mkIf lists;
+
+      getUserPersistence = user: config.home-manager.users.${user}.planet.persistence;
+      users = builtins.attrNames config.home-manager.users;
+      target-users = builtins.filter
+        (user:
+          let
+            user-persistence = getUserPersistence user;
+          in
+          user-persistence.enable && user-persistence.useBindMounts)
+        users;
     in
     mkIf cfg.enable {
       # Opt-in persisted root directories
       environment.persistence.${cfg.persistDirectory} = {
         inherit (cfg) hideMounts;
+
         directories = cfg.directories ++ (lists.optionals cfg.persistSystemdDirectories [
           "/var/lib/systemd/coredump"
           "/var/lib/systemd/timers"
@@ -116,8 +127,18 @@
           ++ (lists.optional cfg.persistSystemdBacklight "/var/lib/systemd/backlight") # for systemd-backlight to be able to restore brightness
           ++ (lists.optional cfg.persistLogs "/var/log")
           ++ (lists.optional cfg.persistSsh "/etc/ssh");
+
         files = cfg.files
           ++ lists.optional cfg.persistMachineId "/etc/machine-id";
+
+        users = lib.attrsets.genAttrs target-users (user:
+          let
+            user-persistence = getUserPersistence user;
+          in
+          {
+            inherit (user-persistence) files;
+            directories = user-persistence.finalDirectories;
+          });
       };
 
       programs.fuse.userAllowOther = cfg.fuseAllowOther;


### PR DESCRIPTION
Bind mounts cannot be created by users, so Impermanence uses `bindfs` instead (can be configured to use symlinks). However, `bindfs` has a performance penalty and some quirks (e.g., moving a file/directory from a `bindfs` mount to another that has the same underlying storage device does a copy and delete).

This PR changes the `planet/nixos/persistence` and `planet/hm/persistence` modules to talk to each other and use bind mounts for user directories where possible.