### PR TITLE
refactor(hm/shiba): remove unused programs

### DIFF
--- a/home-manager/users/shiba/default.nix
+++ b/home-manager/users/shiba/default.nix
@@ -172,7 +172,6 @@
     fd
     ripgrep
     bottom
-    udiskie
     ouch
 
     # Media

--- a/home-manager/users/shiba/default.nix
+++ b/home-manager/users/shiba/default.nix
@@ -168,14 +168,11 @@
     gnome.adwaita-icon-theme
 
     # CLI
-    jq
     eza
     fd
     ripgrep
-    neofetch
     bottom
     udiskie
-    gdb
     ouch
 
     # Media
@@ -186,9 +183,8 @@
     # X
     xdragon
 
-    # Graphical
+    # Miscellaneous
     keepassxc
-    rnote
     android-file-transfer
     drawio
     libreoffice

--- a/planet/modules/home-manager/udiskie/default.nix
+++ b/planet/modules/home-manager/udiskie/default.nix
@@ -1,5 +1,6 @@
 { config
 , lib
+, pkgs
 , ...
 }: {
   options =
@@ -24,6 +25,9 @@
         notify = true;
         tray = "auto";
       };
+
+      # For CLI tools like `udiskie-mount`.
+      home.packages = with pkgs; [ udiskie ];
     };
 }
 


### PR DESCRIPTION
Removes unused programs for `shiba`.

Some of the programs aren't unused, but are better suited to be included in project-specific development shells (e.g., `gdb`).

Lastly, rather than directly adding `udiskie` to `home.packages` in `shiba`'s configuration, it has been added as part of the `planet/hm/udiskie` module.

- refactor(hm/shiba): remove unused programs
- refactor(planet/hm/udiskie): add `udiskie` to package list
