### PR TITLE
refactor(nixos/alpha): re-enable pipewire low latency

### DIFF
--- a/nixos/hosts/alpha/default.nix
+++ b/nixos/hosts/alpha/default.nix
@@ -141,7 +141,7 @@
     nvidia.enable = true;
     pipewire = {
       enable = true;
-      lowLatency = false; # nix-gaming #58
+      lowLatency = true;
     };
     sddm.enable = true;
     tlp = {


### PR DESCRIPTION
Re-enables `nix-gaming`'s low latency module for Pipewire.

The blocking issue has already been resolved.
