### PR TITLE
feat(planet/hm/anki): init

### DIFF
--- a/home-manager/users/shiba/default.nix
+++ b/home-manager/users/shiba/default.nix
@@ -35,6 +35,7 @@
       ];
     };
     android.enable = true;
+    anki.enable = true;
     autorandr = {
       enable = true;
       host = "alpha";

--- a/planet/modules/home-manager/anki/default.nix
+++ b/planet/modules/home-manager/anki/default.nix
@@ -1,0 +1,30 @@
+{ config
+, lib
+, pkgs
+, ...
+}: {
+  options =
+    let
+      inherit (lib) mkEnableOption;
+    in
+    {
+      planet.anki = {
+        enable = mkEnableOption "planet anki";
+      };
+    };
+
+  config =
+    let
+      cfg = config.planet.feh;
+      inherit (lib) mkIf;
+    in
+    mkIf cfg.enable {
+      home.packages = with pkgs; [
+        anki
+      ];
+
+      planet.persistence = {
+        directories = [ ".local/share/Anki2" ];
+      };
+    };
+}

--- a/planet/modules/home-manager/default.nix
+++ b/planet/modules/home-manager/default.nix
@@ -4,6 +4,7 @@ _:
 {
   imports = [
     ./android
+    ./anki
     ./autorandr
     (importModule ./bspwm { })
     ./citra


### PR DESCRIPTION
Adds a `planet` module for Anki and enables it for `shiba`.

- feat(planet/hm/anki): init
- feat(hm/shiba): enable `anki`
