### PR TITLE
feat(planet/hm/neovim): configure Typst LSP and Tree-sitter grammar

### DIFF
--- a/planet/modules/home-manager/editorconfig/default.nix
+++ b/planet/modules/home-manager/editorconfig/default.nix
@@ -30,6 +30,7 @@
           };
           "*.nix" = { indent_size = 2; };
           "*.lua" = { indent_size = 3; };
+          "*.typ" = { indent_size = 2; };
         };
       };
     };

--- a/planet/modules/home-manager/neovim/default.nix
+++ b/planet/modules/home-manager/neovim/default.nix
@@ -60,8 +60,13 @@
     in
     mkIf cfg.enable {
       xdg = {
-        configFile."nvim/lua".source = ./lua;
-        configFile."nvim/ftplugin".source = ./ftplugin;
+        configFile = {
+          "nvim/lua".source = ./lua;
+          "nvim/ftplugin".source = ./ftplugin;
+
+          # See https://github.com/nvim-treesitter/nvim-treesitter#adding-queries.
+          "nvim/queries/typst".source = "${pkgs.tree-sitter-grammars.tree-sitter-typst}/queries";
+        };
         mimeApps.defaultApplications = mkIf cfg.defaultApplication.enable (
           lib.genAttrs cfg.defaultApplication.mimeTypes (_: "nvim.desktop")
         );
@@ -186,6 +191,7 @@
             tree-sitter-python
             tree-sitter-rust
             tree-sitter-toml
+            tree-sitter-typst
             tree-sitter-vim
           ]))
         ];

--- a/planet/modules/home-manager/neovim/default.nix
+++ b/planet/modules/home-manager/neovim/default.nix
@@ -107,6 +107,7 @@
           efm-langserver
           jq
           google-java-format
+          typst-lsp
           cfg.rustToolchain
           (texlive.combine {
             inherit (texlive) scheme-minimal latexindent;

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/init.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/init.lua
@@ -24,6 +24,7 @@ local servers = {
    "python-lsp-server",
    "ltex",
    "hls",
+   "typst-lsp",
 }
 
 local function setup_servers()

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/typst-lsp.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/typst-lsp.lua
@@ -1,0 +1,19 @@
+local M = {}
+
+local lspconfig = require("lspconfig")
+function M.setup(on_attach, capabilities)
+   -- Neovim does not recognize Typst files by default,
+   -- so the filetype needs to be manually registered.
+   vim.filetype.add({
+      extension = {
+         typ = "typst",
+      },
+   })
+
+   lspconfig.typst_lsp.setup({
+      on_attach = on_attach,
+      capabilities = capabilities,
+   })
+end
+
+return M

--- a/planet/modules/home-manager/neovim/lua/plugins/treesitter.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/treesitter.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local ts_configs = require("nvim-treesitter.configs")
+local ts_parsers = require("nvim-treesitter.parsers")
 function M.setup()
    ts_configs.setup({
       highlight = {
@@ -16,6 +17,18 @@ function M.setup()
          },
       },
    })
+
+   -- Add grammar for Typst.
+   local parser_configs = ts_parsers.get_parser_configs()
+   parser_configs.typst = {
+      install_info = {
+         url = "https://github.com/uben0/tree-sitter-typst",
+         files = { "src/parser.c", "src/scanner.c" },
+         generate_requires_npm = false,
+         requires_generate_from_grammar = false,
+      },
+   }
+   vim.treesitter.language.register("typst", "typst")
 end
 
 return M


### PR DESCRIPTION
Configures an LSP server and Tree-sitter grammar for Typst in Neovim.

The grammar from Nixpkgs is outdated and it seems there are rough edges with updating Tree-sitter grammars (with regards to the auto-update script).
I'll have to manually update it or wait for the Typst grammar to be upstreamed into [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter).
Either way, I'll do that outside of this PR because I want to quickly get this merged.