### PR TITLE
refactor(planet/hm/editorconfig): use tabs in Makefiles

### DIFF
--- a/planet/modules/home-manager/editorconfig/default.nix
+++ b/planet/modules/home-manager/editorconfig/default.nix
@@ -31,6 +31,7 @@
           "*.nix" = { indent_size = 2; };
           "*.lua" = { indent_size = 3; };
           "*.typ" = { indent_size = 2; };
+          "{Makefile,makefile}" = { indent_style = "tab"; };
         };
       };
     };


### PR DESCRIPTION
Configure `editorconfig` so that tabs are used in Makefiles.