### PR TITLE
feat(planet/hm/neovim): configure LSP servers and linters for web development

### DIFF
--- a/planet/modules/home-manager/neovim/default.nix
+++ b/planet/modules/home-manager/neovim/default.nix
@@ -117,6 +117,7 @@
           cfg.rustToolchain
           nodePackages.typescript-language-server
           vscode-langservers-extracted
+          htmlhint
           (texlive.combine {
             inherit (texlive) scheme-minimal latexindent;
           })

--- a/planet/modules/home-manager/neovim/default.nix
+++ b/planet/modules/home-manager/neovim/default.nix
@@ -84,6 +84,7 @@
           jdt_ls = "${pkgs.jdt-language-server}/bin/jdt-language-server";
           java_debug_server_dir = "${pkgs.vscode-extensions.vscjava.vscode-java-debug}/share/vscode/extensions/vscjava.vscode-java-debug/server";
           java_test_server_dir = "${pkgs.vscode-extensions.vscjava.vscode-java-test}/share/vscode/extensions/vscjava.vscode-java-test/server";
+          vscode_eslint_language_server_node_path = "${pkgs.nodePackages.eslint}/lib/node_modules";
         });
         extraPackages = with pkgs; [
           ripgrep # Used by telescope

--- a/planet/modules/home-manager/neovim/default.nix
+++ b/planet/modules/home-manager/neovim/default.nix
@@ -115,6 +115,7 @@
           typst-lsp
           cfg.rustToolchain
           nodePackages.typescript-language-server
+          vscode-langservers-extracted
           (texlive.combine {
             inherit (texlive) scheme-minimal latexindent;
           })

--- a/planet/modules/home-manager/neovim/default.nix
+++ b/planet/modules/home-manager/neovim/default.nix
@@ -114,6 +114,7 @@
           google-java-format
           typst-lsp
           cfg.rustToolchain
+          nodePackages.typescript-language-server
           (texlive.combine {
             inherit (texlive) scheme-minimal latexindent;
           })

--- a/planet/modules/home-manager/neovim/init.lua
+++ b/planet/modules/home-manager/neovim/init.lua
@@ -3,6 +3,7 @@ Globals = {
    jdt_ls = "@jdt_ls@",
    java_debug_server_dir = "@java_debug_server_dir@",
    java_test_server_dir = "@java_test_server_dir@",
+   vscode_eslint_language_server_node_path = "@vscode_eslint_language_server_node_path@",
 }
 
 require("options").setup()

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/efm.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/efm.lua
@@ -42,6 +42,13 @@ local google_java_format = {
    formatCommand = "google-java-format -aosp -",
    formatStdin = true,
 }
+local htmlhint = {
+   prefix = "HTMLHint",
+   lintSource = efmls_configs_utils.sourceText("HTMLHint"),
+   lintCommand = "htmlhint --nocolor --format unix stdin",
+   lintStdin = true,
+   lintFormats = { "%f:%l:%c: %m" },
+}
 
 function M.setup(on_attach, capabilities)
    local languages = {
@@ -56,7 +63,10 @@ function M.setup(on_attach, capabilities)
       css = { prettier },
       scss = { prettier },
       less = { prettier },
-      html = { prettier },
+      html = {
+         prettier,
+         htmlhint,
+      },
       json = { prettier },
       jsonc = { prettier },
       yaml = {

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/init.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/init.lua
@@ -27,6 +27,7 @@ local servers = {
    "typst-lsp",
    "tsserver",
    "vscode-html-language-server",
+   "vscode-json-language-server",
 }
 
 local function setup_servers()

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/init.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/init.lua
@@ -26,6 +26,7 @@ local servers = {
    "hls",
    "typst-lsp",
    "tsserver",
+   "vscode-html-language-server",
 }
 
 local function setup_servers()

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/init.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/init.lua
@@ -28,6 +28,7 @@ local servers = {
    "tsserver",
    "vscode-html-language-server",
    "vscode-json-language-server",
+   "vscode-css-language-server",
 }
 
 local function setup_servers()

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/init.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/init.lua
@@ -29,6 +29,7 @@ local servers = {
    "vscode-html-language-server",
    "vscode-json-language-server",
    "vscode-css-language-server",
+   "vscode-eslint-language-server",
 }
 
 local function setup_servers()

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/init.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/init.lua
@@ -25,6 +25,7 @@ local servers = {
    "ltex",
    "hls",
    "typst-lsp",
+   "tsserver",
 }
 
 local function setup_servers()

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/tsserver.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/tsserver.lua
@@ -1,0 +1,14 @@
+local M = {}
+
+local lspconfig = require("lspconfig")
+function M.setup(on_attach, capabilities)
+   -- Let Prettier do the formatting
+   capabilities.document_formatting = false
+   capabilities.document_range_formatting = false
+   lspconfig.tsserver.setup({
+      on_attach = on_attach,
+      capabilities = capabilities,
+   })
+end
+
+return M

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/vscode-css-language-server.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/vscode-css-language-server.lua
@@ -1,0 +1,16 @@
+local M = {}
+
+local lspconfig = require("lspconfig")
+function M.setup(on_attach, capabilities)
+   -- Enable completion using snippets
+   capabilities.textDocument.completion.completionItem.snippetSupport = true
+   lspconfig.cssls.setup({
+      on_attach = on_attach,
+      capabilities = capabilities,
+      init_options = {
+         provideFormatter = false, -- Let Prettier do the formatting
+      },
+   })
+end
+
+return M

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/vscode-eslint-language-server.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/vscode-eslint-language-server.lua
@@ -1,0 +1,19 @@
+local M = {}
+
+local lspconfig = require("lspconfig")
+function M.setup(on_attach, capabilities)
+   lspconfig.eslint.setup({
+      on_attach = on_attach,
+      capabilities = capabilities,
+      settings = {
+         -- The server can automatically fix problems by "formatting".
+         -- I don't want this, and this will probably conflict with Prettier anyway.
+         format = false,
+
+         -- Required, otherwise the language server will not be able to find the ESLint library
+         nodePath = Globals.vscode_eslint_language_server_node_path,
+      },
+   })
+end
+
+return M

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/vscode-html-language-server.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/vscode-html-language-server.lua
@@ -1,0 +1,16 @@
+local M = {}
+
+local lspconfig = require("lspconfig")
+function M.setup(on_attach, capabilities)
+   -- Enable completion using snippets
+   capabilities.textDocument.completion.completionItem.snippetSupport = true
+   lspconfig.html.setup({
+      on_attach = on_attach,
+      capabilities = capabilities,
+      init_options = {
+         provideFormatter = false, -- Let Prettier do the formatting
+      },
+   })
+end
+
+return M

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/vscode-json-language-server.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/vscode-json-language-server.lua
@@ -1,0 +1,16 @@
+local M = {}
+
+local lspconfig = require("lspconfig")
+function M.setup(on_attach, capabilities)
+   -- Enable completion using snippets
+   capabilities.textDocument.completion.completionItem.snippetSupport = true
+   lspconfig.jsonls.setup({
+      on_attach = on_attach,
+      capabilities = capabilities,
+      init_options = {
+         provideFormatter = false, -- Let Prettier do the formatting
+      },
+   })
+end
+
+return M


### PR DESCRIPTION
Configures the following linters / LSP servers for Neovim:

- [`typescript-language-server`](https://github.com/typescript-language-server/typescript-language-server)
- [`vscode-html-language-server`](https://github.com/hrsh7th/vscode-langservers-extracted)
- [`vscode-css-language-server`](https://github.com/hrsh7th/vscode-langservers-extracted)
- [`vscode-json-language-server`](https://github.com/hrsh7th/vscode-langservers-extracted)
- [`vscode-eslint-language-server`](https://github.com/hrsh7th/vscode-langservers-extracted)
- [HTMLHint](https://github.com/htmlhint/HTMLHint)