### PR TITLE
Add Linux and POSIX `man` pages to `shiba`

### DIFF
--- a/home-manager/users/shiba/default.nix
+++ b/home-manager/users/shiba/default.nix
@@ -45,6 +45,7 @@
       primaryMonitor = "eDP-1";
     };
     citra.enable = false; # FIXME: Wait for the dust to settle.
+    dev-man-pages.enable = true;
     direnv.enable = true;
     discord.enable = true;
     editorconfig.enable = true;

--- a/planet/modules/home-manager/default.nix
+++ b/planet/modules/home-manager/default.nix
@@ -9,6 +9,7 @@ _:
     (importModule ./bspwm { })
     ./citra
     ./default-terminal
+    ./dev-man-pages
     ./direnv
     ./discord
     ./editorconfig

--- a/planet/modules/home-manager/dev-man-pages/default.nix
+++ b/planet/modules/home-manager/dev-man-pages/default.nix
@@ -1,0 +1,27 @@
+{ config
+, pkgs
+, lib
+, ...
+}: {
+  options =
+    let
+      inherit (lib) mkEnableOption;
+    in
+    {
+      planet.dev-man-pages = {
+        enable = mkEnableOption "planet dev-man-pages";
+      };
+    };
+
+  config =
+    let
+      cfg = config.planet.dev-man-pages;
+      inherit (lib) mkIf;
+    in
+    mkIf cfg.enable {
+      home.packages = with pkgs; [
+        man-pages
+        man-pages-posix
+      ];
+    };
+}


### PR DESCRIPTION
Adds Linux and POSIX `man` pages to the `shiba` user.

The specific packages of the `man` pages that have been added are as recommended by https://nixos.wiki/wiki/Man_pages.
