### PR TITLE
Allow using Firefox as the default browser

### DIFF
--- a/home-manager/users/shiba/default.nix
+++ b/home-manager/users/shiba/default.nix
@@ -57,7 +57,10 @@
       enable = true;
       defaultApplication.enable = true;
     };
-    firefox.enable = true;
+    firefox = {
+      enable = true;
+      defaultApplication.enable = true;
+    };
     fish.enable = true;
     flameshot = {
       enable = true;
@@ -115,10 +118,7 @@
     polkit-agent.enable = true;
     polybar.enable = true;
     qt.enable = true;
-    qutebrowser = {
-      enable = true;
-      defaultApplication.enable = true;
-    };
+    qutebrowser.enable = true;
     redshift = {
       enable = true;
       systemd.target = "bspwm-session.target";

--- a/planet/modules/home-manager/firefox/default.nix
+++ b/planet/modules/home-manager/firefox/default.nix
@@ -4,11 +4,26 @@
 }: {
   options =
     let
-      inherit (lib) mkEnableOption;
+      inherit (lib) mkEnableOption mkOption types;
     in
     {
       planet.firefox = {
         enable = mkEnableOption "planet firefox";
+        defaultApplication = {
+          enable = mkEnableOption "MIME default application configuration";
+          mimeTypes = mkOption {
+            type = types.listOf types.str;
+            default = [
+              "text/html"
+              "application/xhtml+xml"
+              "x-scheme-handler/http"
+              "x-scheme-handler/https"
+            ];
+            description = ''
+              MIME types to be the default application for.
+            '';
+          };
+        };
       };
     };
 
@@ -32,5 +47,9 @@
       planet.persistence = {
         directories = [ ".mozilla" ];
       };
+
+      xdg.mimeApps.defaultApplications = mkIf cfg.defaultApplication.enable (
+        lib.genAttrs cfg.defaultApplication.mimeTypes (_: "firefox.desktop")
+      );
     };
 }


### PR DESCRIPTION
Adds an option to use Firefox as the default browser.

For `shiba`, Firefox is now the default instead of qutebrowser.
