### PR TITLE
Fix casing for `catppuccin-cursors` cursor theme

### DIFF
--- a/planet/modules/home-manager/pointer-cursor/default.nix
+++ b/planet/modules/home-manager/pointer-cursor/default.nix
@@ -20,7 +20,7 @@
     in
     mkIf cfg.enable {
       home.pointerCursor = {
-        name = "Catppuccin-Macchiato-Dark-Cursors";
+        name = "catppuccin-macchiato-dark-cursors";
         package = pkgs.catppuccin-cursors.macchiatoDark;
         x11.enable = true;
         gtk.enable = true;


### PR DESCRIPTION
v0.2.1 of `catppuccin-cursors` seems to have changed the casing to lowercase.
