### PR TITLE
Add Zellij

### DIFF
--- a/home-manager/users/shiba/default.nix
+++ b/home-manager/users/shiba/default.nix
@@ -154,6 +154,7 @@
       systemd.target = "hyprland-session.target";
     };
     yuzu.enable = false; # FIXME: Wait for the dust to settle.
+    zellij.enable = true;
     zotero.enable = true;
     zoxide.enable = true;
   };

--- a/planet/modules/home-manager/default.nix
+++ b/planet/modules/home-manager/default.nix
@@ -60,6 +60,7 @@ _:
     ./xdg-terminal-exec
     ./yuzu
     (importModule ./zathura { })
+    ./zellij
     ./zotero
     ./zoxide
   ];

--- a/planet/modules/home-manager/wezterm/wezterm.fnl
+++ b/planet/modules/home-manager/wezterm/wezterm.fnl
@@ -2,7 +2,7 @@
 
 (local wezterm (require :wezterm))
 
-{:default_prog ["@default_shell@" "-l"]
+{:default_prog [@default_prog_args@]
  :launch_menu [{:label "Bash" :args ["bash" "-l"]}]
  :color_scheme "Catppuccin Macchiato"
  :font (wezterm.font_with_fallback ["Iosevka Term Custom"

--- a/planet/modules/home-manager/zellij/config.kdl
+++ b/planet/modules/home-manager/zellij/config.kdl
@@ -1,0 +1,11 @@
+default_shell "fish"
+
+pane_frames false
+
+serialize_pane_viewport true
+
+theme "catppuccin-macchiato"
+
+default_layout "compact"
+
+disable_session_metadata true

--- a/planet/modules/home-manager/zellij/default.nix
+++ b/planet/modules/home-manager/zellij/default.nix
@@ -1,0 +1,35 @@
+{ config
+, pkgs
+, lib
+, ...
+}: {
+  options =
+    let
+      inherit (lib) mkEnableOption;
+    in
+    {
+      planet.zellij = {
+        enable = mkEnableOption "planet zellij";
+      };
+    };
+
+  config =
+    let
+      cfg = config.planet.zellij;
+      inherit (lib) mkIf;
+
+    in
+    mkIf cfg.enable {
+      home.packages = with pkgs; [
+        zellij
+      ];
+
+      planet.persistence = {
+        directories = [
+          ".cache/zellij"
+        ];
+      };
+
+      xdg.configFile."zellij/config.kdl".source = ./config.kdl;
+    };
+}


### PR DESCRIPTION
Adds configuration for Zellij and enables it for `shiba`.