### PR TITLE
Work around r8152 bug caused by USB suspend

### DIFF
--- a/nixos/hosts/alpha/default.nix
+++ b/nixos/hosts/alpha/default.nix
@@ -165,6 +165,15 @@
         "nvme0n1"
         "sda"
       ];
+      extraSettings = {
+        # For getting the Wavlink 5gbps adapter to work.
+        # See:
+        # - https://askubuntu.com/questions/1044127/usb-ethernet-adapter-realtek-r8153-keeps-disconnecting
+        # - https://forum.manjaro.org/t/no-carrier-network-link-problem-with-usb-2-5-gbit-lan-adapter-realtek-rtl8156b-on-x86-64/97195
+        # - https://community.frame.work/t/solved-getting-the-rtl8156-2-5gb-adapter-on-ubuntu-22-04-solution-blacklist-tlp-from-device/23857/4
+        # ID was retrieved with `lsusb`.
+        USB_DENYLIST = "0bda:8157";
+      };
     };
     udisks2.enable = true;
     upower.enable = true;

--- a/planet/modules/nixos/tlp/default.nix
+++ b/planet/modules/nixos/tlp/default.nix
@@ -17,6 +17,22 @@
             List of disk devices for TLP to act on.
           '';
         };
+        extraSettings = mkOption {
+          type =
+            with lib.types;
+            attrsOf (oneOf [
+              bool
+              int
+              float
+              str
+              (listOf str)
+            ]);
+          default = { };
+          description = ''
+            Extra options passed to TLP to be merged with the default settings.
+            See https://linrunner.de/tlp for all supported options.
+          '';
+        };
       };
     };
 
@@ -36,7 +52,7 @@
           DEVICES_TO_ENABLE_ON_LAN_DISCONNECT = "wifi";
           DEVICES_TO_DISABLE_ON_BAT_NOT_IN_USE = "bluetooth";
           DEVICES_TO_DISABLE_ON_STARTUP = "bluetooth wwan";
-        };
+        } // cfg.extraSettings;
       };
     };
 }


### PR DESCRIPTION
This workaround is for a Wavlink 5-gigabit Ethernet adapter (WL-NWU340G), which uses RTL8157. It seems TLP's USB autosuspend somehow interferes with the r8152 kernel module, so the USB device needs to be excluded from TLP's USB autosuspend.

More details can be found in the links in the comment for the TLP USB denylist.