### PR TITLE
Update Realtek r8152 driver

### DIFF
--- a/planet/pkgs/flake-module.nix
+++ b/planet/pkgs/flake-module.nix
@@ -25,6 +25,9 @@
           catppuccin-rofi = prev.callPackage ./catppuccin-rofi { };
           iosevka-custom = prev.callPackage ./iosevka-custom { };
           iosevka-term-custom = prev.callPackage ./iosevka-custom { spacing = "term"; };
+          kernelModules = {
+            realtek-r8152 = ./realtek-r8152;
+          };
           # vimPlugins = prev.lib.recurseIntoAttrs (prev.callPackage ./vim-plugins { });
         };
       };

--- a/planet/pkgs/realtek-r8152/default.nix
+++ b/planet/pkgs/realtek-r8152/default.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  fetchFromGitHub,
+  kernel,
+  stdenv,
+}:
+
+let
+  version = "2.19.2";
+in
+stdenv.mkDerivation {
+  pname = "realtek-r8152";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "wget";
+    repo = "realtek-r8152-linux";
+    rev = "v${version}";
+    sha256 = "sha256-9kJF7y1T0/5yxxsIrQycKY53Ksd8JxMEpVXNjX0WRao=";
+  };
+
+  hardeningDisable = [
+    "pic"
+    "format"
+  ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+  TARGET_PATH = "kernel/drivers/net/usb";
+
+  inherit (kernel) makeFlags;
+
+  # Avoid using the Makefile directly since it does some shenanigans.
+  buildPhase = ''
+    runHook preBuild
+
+    make -C "$KERNELDIR" M="$PWD" modules
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    make -C "$KERNELDIR" M="$PWD" INSTALL_MOD_PATH="$out" INSTALL_MOD_DIR="$TARGET_PATH" modules_install
+
+    # Install udev rules.
+    mkdir -p $out/etc/udev/rules.d
+    cp 50-usb-realtek-net.rules $out/etc/udev/rules.d/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A kernel module for Realtek RTL8152/RTL8153 Based USB Ethernet Adapters";
+    license = lib.licenses.gpl2Only;
+    homepage = "https://github.com/wget/realtek-r8152-linux";
+    maintainers = with lib.maintainers; [ dixslyf ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
This PR updates the r8152 driver to the latest version released by Realtek and includes a bunch of udev rules to load the driver for the appropriate devices.

Although the mainline kernel includes this driver, it includes an older version of it — waiting for the latest version to be upstreamed will likely take a long time.

The motivation for this PR is a Wavlink 5Gbps Ethernet adapter (WL-NWU340G Rev. a), which uses the RTL8157 chip and does not function properly with the cdc_ncm (loaded by default for RTL8157 without the udev rules) and r8152 drivers in the mainline kernel.