### PR TITLE
KMonad Configuration for SPM AL68A

### DIFF
--- a/nixos/hosts/alpha/default.nix
+++ b/nixos/hosts/alpha/default.nix
@@ -113,7 +113,6 @@
       enable = true;
       xkb = {
         layout = "us";
-        options = "compose:ralt"; # Use right alt as the compose key.
       };
       displayManager = {
         # Set the background color of the root window

--- a/nixos/hosts/alpha/kmonad/default.nix
+++ b/nixos/hosts/alpha/kmonad/default.nix
@@ -15,6 +15,11 @@
         defcfg.enable = true;
         config = builtins.readFile ./ducky-one-2-mini.kbd;
       };
+      spmAl68a = {
+        device = "/dev/input/by-id/usb-Hangsheng_AL68A-if02-event-kbd";
+        defcfg.enable = true;
+        config = builtins.readFile ./spm-al68a.kbd;
+      };
     };
   };
 }

--- a/nixos/hosts/alpha/kmonad/spm-al68a.kbd
+++ b/nixos/hosts/alpha/kmonad/spm-al68a.kbd
@@ -1,0 +1,97 @@
+(defsrc
+  esc   1     2     3     4     5     6     7     8     9     0     -     =      caps
+  grv   f1    f2    f3    f4    f5    f6    f7    f8    f9    f10   f11   f12
+
+  tab     q     w     e     r     t     y     u     i     o     p     [     ]       \     del
+                                                                            ssrq
+
+  bspc     a     s     d     f     g     h     j     k     l     ;     '          ret    pgup
+                                                                 brup  brdn              home
+
+  lsft        z     x     c     v     b     n     m     ,     .     /      rsft    up    pgdn
+                                                                                          end
+
+  lctl   lmet   lalt         spc        rmet                ralt            lft   down   rght
+                                                            rctrl
+)
+
+
+#| -----------------------------------------------------------------------------
+
+                                 Template Layer
+
+(deflayer name
+  _     _     _     _     _     _     _     _     _     _     _     _     _        _
+  _     _     _     _     _     _     _     _     _     _     _     _     _
+
+  _       _     _     _     _     _     _     _     _     _     _     _     _      _      _
+                                                                            _
+
+  _        _     _     _     _     _     _     _     _     _     _     _           _      _
+                                                                 _     _                  _
+
+  _           _     _     _     _     _     _     _     _     _     _       _      _      _
+                                                                                          _
+
+  _      _      _            _          _                   _               _      _      _
+                                                            _
+)
+
+   ----------------------------------------------------------------------------- |#
+
+(defalias
+  sw (layer-toggle layout-switch)
+  qw (layer-switch qwerty)
+  cny (layer-switch canary)
+)
+
+(deflayer qwerty
+  esc   1     2     3     4     5     6     7     8     9     0     -     =      caps
+  grv   f1    f2    f3    f4    f5    f6    f7    f8    f9    f10   f11   f12
+
+  tab     q     w     e     r     t     y     u     i     o     p     [     ]       \     del
+                                                                            ssrq
+
+  bspc     a     s     d     f     g     h     j     k     l     ;     '          ret    pgup
+                                                                 brup  brdn              home
+
+  lsft        z     x     c     v     b     n     m     ,     .     /      rsft    up    pgdn
+                                                                                          end
+
+  lctl   lmet   lalt         spc        @sw                 ralt            lft   down   rght
+                                                            rctrl
+)
+
+(deflayer layout-switch
+  _     _     _     _     _     _     _     _     _     _     _     _     _        _
+  _     _     _     _     _     _     _     _     _     _     _     _     _
+
+  _       @qw   _     _     _     _     _     _     _     _     _     _     _      _      _
+                                                                            _
+
+  _        _     _     _     _     _     _     _     _     _     _     _           _      _
+                                                                 _     _                  _
+
+  _           _     _     @cny  _     _     _     _     _     _     _       _      _      _
+                                                                                          _
+
+  _      _      _            _          _                   _               _      _      _
+                                                            _
+)
+
+(deflayer canary
+  esc   1     2     3     4     5     6     7     8     9     0     -     =      caps
+  grv   f1    f2    f3    f4    f5    f6    f7    f8    f9    f10   f11   f12
+
+  tab     w     l     y     p     k     z     x     o     u     ;     [     ]       \     del
+                                                                            ssrq
+
+  bspc     c     r     s     t     b     f     n     e     i     a     '          ret    pgup
+                                                                 brup  brdn              home
+
+  lsft        j     v     d     g     q     m     h     /     ,     .      rsft    up    pgdn
+                                                                                          end
+
+  lctl   lmet   lalt         spc        @sw                 ralt            lft   down   rght
+                                                            rctrl
+)


### PR DESCRIPTION
Adds a KMonad configuration for SPM AL68A. The configuration defines layers for both the qwerty and canary layouts.