### PR TITLE
Update `lspconfig` configuration to Neovim 0.11 format

### DIFF
--- a/planet/modules/home-manager/neovim/default.nix
+++ b/planet/modules/home-manager/neovim/default.nix
@@ -125,6 +125,7 @@
             vscode-langservers-extracted
             htmlhint
             gopls
+            svelte-language-server
             (texlive.combine {
               inherit (texlive) scheme-minimal latexindent;
             })

--- a/planet/modules/home-manager/neovim/default.nix
+++ b/planet/modules/home-manager/neovim/default.nix
@@ -208,6 +208,7 @@
               tree-sitter-nix
               tree-sitter-python
               tree-sitter-rust
+              tree-sitter-svelte
               tree-sitter-toml
               tree-sitter-tsx
               tree-sitter-typescript

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/clangd.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/clangd.lua
@@ -1,9 +1,9 @@
 local M = {}
 
-local lspconfig = require("lspconfig")
 function M.setup(on_attach, capabilities)
    capabilities.offsetEncoding = { "utf-16" }
-   lspconfig.clangd.setup({
+   vim.lsp.enable("clangd")
+   vim.lsp.config("clangd", {
       on_attach = on_attach,
       capabilities = capabilities,
    })

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/efm.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/efm.lua
@@ -1,7 +1,5 @@
 local M = {}
 
-local lspconfig = require("lspconfig")
-
 local efmls_configs_utils = require("efmls-configs.utils")
 
 local stylua = require("efmls-configs.formatters.stylua")
@@ -98,7 +96,8 @@ function M.setup(on_attach, capabilities)
       ["="] = { editorconfig_checker },
    }
 
-   lspconfig.efm.setup({
+   vim.lsp.enable("efm")
+   vim.lsp.config("efm", {
       on_attach = on_attach,
       capabilities = capabilities,
       filetypes = vim.tbl_keys(languages),

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/gopls.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/gopls.lua
@@ -1,8 +1,8 @@
 local M = {}
 
-local lspconfig = require("lspconfig")
 function M.setup(on_attach, capabilities)
-   lspconfig.gopls.setup({
+   vim.lsp.enable("gopls")
+   vim.lsp.config("gopls", {
       on_attach = on_attach,
       capabilities = capabilities,
    })

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/hls.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/hls.lua
@@ -1,8 +1,8 @@
 local M = {}
 
-local lspconfig = require("lspconfig")
 function M.setup(on_attach, capabilities)
-   lspconfig.hls.setup({
+   vim.lsp.enable("hls")
+   vim.lsp.config("hls", {
       on_attach = on_attach,
       capabilities = capabilities,
    })

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/init.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/init.lua
@@ -22,6 +22,7 @@ local servers = {
    "gopls",
    "clangd",
    "rust-analyzer",
+   "svelte-language-server",
    "python-lsp-server",
    "ltex",
    "hls",

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/ltex.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/ltex.lua
@@ -1,8 +1,8 @@
 local M = {}
 
-local lspconfig = require("lspconfig")
 function M.setup(on_attach, capabilities)
-   lspconfig.ltex.setup({
+   vim.lsp.enable("ltex")
+   vim.lsp.config("ltex", {
       on_attach = on_attach,
       capabilities = capabilities,
       settings = {

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/lua-ls.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/lua-ls.lua
@@ -1,11 +1,11 @@
 local M = {}
 
 local neodev = require("neodev")
-local lspconfig = require("lspconfig")
 function M.setup(on_attach, capabilities)
    neodev.setup()
 
-   lspconfig.lua_ls.setup({
+   vim.lsp.enable("lua_ls")
+   vim.lsp.config("lua_ls", {
       on_attach = on_attach,
       capabilities = capabilities,
       settings = {

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/nil-ls.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/nil-ls.lua
@@ -1,8 +1,8 @@
 local M = {}
 
-local lspconfig = require("lspconfig")
 function M.setup(on_attach, capabilities)
-   lspconfig.nil_ls.setup({
+   vim.lsp.enable("nil_ls")
+   vim.lsp.config("nil_ls", {
       on_attach = on_attach,
       capabilities = capabilities,
       settings = {

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/python-lsp-server.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/python-lsp-server.lua
@@ -1,8 +1,8 @@
 local M = {}
 
-local lspconfig = require("lspconfig")
 function M.setup(on_attach, capabilities)
-   lspconfig.pylsp.setup({
+   vim.lsp.enable("pylsp")
+   vim.lsp.config("pylsp", {
       on_attach = on_attach,
       capabilities = capabilities,
       settings = {

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/rust-analyzer.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/rust-analyzer.lua
@@ -1,8 +1,8 @@
 local M = {}
 
-local lspconfig = require("lspconfig")
 function M.setup(on_attach, capabilities)
-   lspconfig.rust_analyzer.setup({
+   vim.lsp.enable("rust_analyzer")
+   vim.lsp.config("rust_analyzer", {
       on_attach = on_attach,
       capabilities = capabilities,
       settings = {

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/svelte-language-server.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/svelte-language-server.lua
@@ -1,8 +1,8 @@
 local M = {}
 
-local lspconfig = require("lspconfig")
 function M.setup(on_attach, capabilities)
-   lspconfig.svelte.setup({
+   vim.lsp.enable("svelte")
+   vim.lsp.config("svelte", {
       on_attach = on_attach,
       capabilities = capabilities,
    })

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/svelte-language-server.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/svelte-language-server.lua
@@ -1,0 +1,11 @@
+local M = {}
+
+local lspconfig = require("lspconfig")
+function M.setup(on_attach, capabilities)
+   lspconfig.svelte.setup({
+      on_attach = on_attach,
+      capabilities = capabilities,
+   })
+end
+
+return M

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/tinymist.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/tinymist.lua
@@ -1,6 +1,5 @@
 local M = {}
 
-local lspconfig = require("lspconfig")
 function M.setup(on_attach, capabilities)
    -- Neovim does not recognize Typst files by default,
    -- so the filetype needs to be manually registered.
@@ -10,7 +9,8 @@ function M.setup(on_attach, capabilities)
       },
    })
 
-   lspconfig.tinymist.setup({
+   vim.lsp.enable("tinymist")
+   vim.lsp.config("tinymist", {
       on_attach = on_attach,
       capabilities = capabilities,
       settings = {

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/ts-ls.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/ts-ls.lua
@@ -1,11 +1,11 @@
 local M = {}
 
-local lspconfig = require("lspconfig")
 function M.setup(on_attach, capabilities)
    -- Let Prettier do the formatting
    capabilities.document_formatting = false
    capabilities.document_range_formatting = false
-   lspconfig.ts_ls.setup({
+   vim.lsp.enable("ts_ls")
+   vim.lsp.config("ts_ls", {
       on_attach = on_attach,
       capabilities = capabilities,
    })

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/vscode-css-language-server.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/vscode-css-language-server.lua
@@ -1,10 +1,10 @@
 local M = {}
 
-local lspconfig = require("lspconfig")
 function M.setup(on_attach, capabilities)
    -- Enable completion using snippets
    capabilities.textDocument.completion.completionItem.snippetSupport = true
-   lspconfig.cssls.setup({
+   vim.lsp.enable("cssls")
+   vim.lsp.config("cssls", {
       on_attach = on_attach,
       capabilities = capabilities,
       init_options = {

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/vscode-eslint-language-server.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/vscode-eslint-language-server.lua
@@ -1,8 +1,8 @@
 local M = {}
 
-local lspconfig = require("lspconfig")
 function M.setup(on_attach, capabilities)
-   lspconfig.eslint.setup({
+   vim.lsp.enable("eslint")
+   vim.lsp.config("eslint", {
       on_attach = on_attach,
       capabilities = capabilities,
       settings = {

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/vscode-html-language-server.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/vscode-html-language-server.lua
@@ -1,10 +1,10 @@
 local M = {}
 
-local lspconfig = require("lspconfig")
 function M.setup(on_attach, capabilities)
    -- Enable completion using snippets
    capabilities.textDocument.completion.completionItem.snippetSupport = true
-   lspconfig.html.setup({
+   vim.lsp.enable("html")
+   vim.lsp.config("html", {
       on_attach = on_attach,
       capabilities = capabilities,
       init_options = {

--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/vscode-json-language-server.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/vscode-json-language-server.lua
@@ -1,10 +1,10 @@
 local M = {}
 
-local lspconfig = require("lspconfig")
 function M.setup(on_attach, capabilities)
    -- Enable completion using snippets
    capabilities.textDocument.completion.completionItem.snippetSupport = true
-   lspconfig.jsonls.setup({
+   vim.lsp.enable("jsonls")
+   vim.lsp.config("jsonls", {
       on_attach = on_attach,
       capabilities = capabilities,
       init_options = {


### PR DESCRIPTION
It seems like some of `lspconfig` has been upstreamed into Neovim 0.11, so the configuration syntax is now different. This PR updates the `lspconfig` configuration to this new syntax and also configures Svelte language server.