### PR TITLE
Fix rust analyzer LSP configuration in Neovim

### DIFF
--- a/planet/modules/home-manager/neovim/lua/plugins/lspconfig/rust-analyzer.lua
+++ b/planet/modules/home-manager/neovim/lua/plugins/lspconfig/rust-analyzer.lua
@@ -7,8 +7,9 @@ function M.setup(on_attach, capabilities)
       capabilities = capabilities,
       settings = {
          ["rust-analyzer"] = {
-            checkOnSave = {
-               allFeatures = true,
+            checkOnSave = true,
+            check = {
+               features = "all",
                overrideCommand = {
                   "cargo",
                   "clippy",


### PR DESCRIPTION
Seems like the configuration format changed at some point.

https://rust-analyzer.github.io/book/configuration.html