### PR TITLE
Downgrade NVIDIA drivers to 550.142

### DIFF
--- a/nixos/hosts/alpha/hardware/default.nix
+++ b/nixos/hosts/alpha/hardware/default.nix
@@ -168,7 +168,14 @@
         intelBusId = "PCI:0:2:0";
         nvidiaBusId = "PCI:2:0:0";
       };
-      package = config.boot.kernelPackages.nvidiaPackages.latest;
+      package = config.boot.kernelPackages.nvidiaPackages.mkDriver {
+        version = "550.142";
+        sha256_64bit = "sha256-bdVJivBLQtlSU7Zre9oVCeAbAk0s10WYPU3Sn+sXkqE=";
+        sha256_aarch64 = "sha256-sBp5fcCPMrfrTZTF1FqKo9g0wOWP+5+wOwQ7PLWI6wA=";
+        openSha256 = "sha256-hjpwTR4I0MM5dEjQn7MKM3RY1a4Mt6a61Ii9KW2KbiY=";
+        settingsSha256 = "sha256-Wk6IlVvs23cB4s0aMeZzSvbOQqB1RnxGMv3HkKBoIgY=";
+        persistencedSha256 = "ssha256-yQFrVk4i2dwReN0XoplkJ++iA1WFhnIkP7ns4ORmkFA=";
+      };
     };
     graphics = {
       enable = true;


### PR DESCRIPTION
The latest NVIDIA drivers (575.xx) unfortunately sometimes cause games to freeze.
Previously, I could not remain on 550.xx due to some incompatibility with the kernel,
but that issue seems to be gone.
