### PR TITLE
Remove redundant uses of `importApply`

### DIFF
--- a/planet/modules/home-manager/bspwm/default.nix
+++ b/planet/modules/home-manager/bspwm/default.nix
@@ -1,6 +1,5 @@
 {
   localFlake,
-  localFlake',
   ...
 }:
 
@@ -35,7 +34,7 @@
       # More details: https://github.com/NixOS/nixpkgs/issues/190442
       xsession.windowManager.bspwm = {
         enable = true;
-        package = localFlake'.packages.bspwm;
+        package = pkgs.pers-pkgs.bspwm;
         monitors = {
           ${cfg.primaryMonitor} = [
             "p1"
@@ -109,7 +108,8 @@
                           right 20 0 || bspc node -z left 20 0}
           '';
           "super + {_,shift} + {u,i}" = "bspc {monitor -f,node -m} {prev,next}"; # focus or send to the next monitor
-          "super + {1-9,0} + {_,shift}" = ''num={1-9,10}; if [ $(bspc query -D -d focused --names | cut -c 2) != "$num" ]; then bspc {desktop -f,node -d} focused:^"$num"; fi''; # focus / move window to desktop
+          "super + {1-9,0} + {_,shift}" =
+            ''num={1-9,10}; if [ $(bspc query -D -d focused --names | cut -c 2) != "$num" ]; then bspc {desktop -f,node -d} focused:^"$num"; fi''; # focus / move window to desktop
           "super + {o,p}" = "bspc desktop -f {prev,next}.local"; # focus the next/prev desktop in the current monitor
           "super + Return" = "wezterm"; # open terminal
           "{XF86MonBrightnessUp,XF86MonBrightnessDown} + {_,shift}" = "light -{A,U} {0.2,1}";
@@ -117,7 +117,8 @@
           "{XF86AudioRaiseVolume,XF86AudioLowerVolume} + {_,shift}" = "pamixer -{i,d} {1,2}";
           "XF86AudioMute" = "pamixer --toggle-mute";
           "super + r" = "rofi -show drun";
-          "super + g" = "if [ \"$(bspc config window_gap)\" -eq 0 ]; then bspc config window_gap 12; bspc config border_width 2; else bspc config window_gap 0; bspc config border_width 0; fi";
+          "super + g" =
+            "if [ \"$(bspc config window_gap)\" -eq 0 ]; then bspc config window_gap 12; bspc config border_width 2; else bspc config window_gap 0; bspc config border_width 0; fi";
           "Print" = "flameshot gui";
         };
       };

--- a/planet/modules/home-manager/cambridge/default.nix
+++ b/planet/modules/home-manager/cambridge/default.nix
@@ -1,7 +1,7 @@
-{ localFlake', ... }:
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 {
@@ -22,7 +22,7 @@
     in
     mkIf cfg.enable {
       home.packages = [
-        localFlake'.packages.cambridge
+        pkgs.pers-pkgs.cambridge
       ];
 
       planet.persistence = {

--- a/planet/modules/home-manager/default.nix
+++ b/planet/modules/home-manager/default.nix
@@ -6,7 +6,7 @@ _: {
     ./anki
     ./autorandr
     (importModule ./bspwm { })
-    (importModule ./cambridge { })
+    ./cambridge
     ./citra
     ./default-terminal
     ./dev-man-pages
@@ -17,22 +17,22 @@ _: {
     ./feh
     ./file-roller
     ./firefox
-    (importModule ./fish { })
+    ./fish
     ./flameshot
     ./fzf
     ./git
     ./gh
-    (importModule ./gitui { })
+    ./gitui
     ./glab
     ./gpg
     ./gpg-agent
-    (importModule ./gtk { })
+    ./gtk
     (importModule ./hyprland { })
     ./kdenlive
-    (importModule ./kitty { })
+    ./kitty
     ./logseq
     ./lutris
-    (importModule ./mako { })
+    ./mako
     ./mpv
     ./mullvad-browser
     ./mullvad-vpn
@@ -44,14 +44,14 @@ _: {
     ./picom
     ./pointer-cursor
     ./polkit-agent
-    (importModule ./polybar { })
+    ./polybar
     ./qbittorrent
     ./qmk
     ./qt
     ./qutebrowser
     ./redshift
-    (importModule ./rofi { })
-    (importModule ./sioyek { })
+    ./rofi
+    ./sioyek
     ./ssh
     ./tealdeer
     ./techmino
@@ -59,13 +59,13 @@ _: {
     ./thunar
     ./tray-target
     ./udiskie
-    (importModule ./waybar { })
-    (importModule ./wezterm { })
+    ./waybar
+    ./wezterm
     (importModule ./wired { })
-    (importModule ./wlsunset { })
+    ./wlsunset
     ./xdg-terminal-exec
     ./yuzu
-    (importModule ./zathura { })
+    ./zathura
     ./zellij
     ./zotero
     ./zoxide

--- a/planet/modules/home-manager/fish/default.nix
+++ b/planet/modules/home-manager/fish/default.nix
@@ -1,4 +1,3 @@
-{ localFlake', ... }:
 {
   config,
   lib,
@@ -39,7 +38,7 @@
         };
 
       xdg.configFile."fish/themes" = {
-        source = "${localFlake'.packages.catppuccin-fish}/share/fish/themes";
+        source = "${pkgs.pers-pkgs.catppuccin-fish}/share/fish/themes";
         recursive = true;
       };
     };

--- a/planet/modules/home-manager/gitui/default.nix
+++ b/planet/modules/home-manager/gitui/default.nix
@@ -1,7 +1,7 @@
-{ localFlake', ... }:
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 {
@@ -24,7 +24,7 @@
       programs.gitui = {
         enable = true;
         keyConfig = builtins.readFile ./key_bindings.ron;
-        theme = builtins.readFile "${localFlake'.packages.catppuccin-gitui}/share/gitui/catppuccin-macchiato.ron";
+        theme = builtins.readFile "${pkgs.pers-pkgs.catppuccin-gitui}/share/gitui/catppuccin-macchiato.ron";
       };
     };
 }

--- a/planet/modules/home-manager/gtk/default.nix
+++ b/planet/modules/home-manager/gtk/default.nix
@@ -1,4 +1,3 @@
-{ localFlake', ... }:
 {
   config,
   lib,
@@ -22,7 +21,7 @@
       inherit (lib) mkIf;
     in
     mkIf cfg.enable {
-      home.packages = [ localFlake'.packages.mali ];
+      home.packages = [ pkgs.pers-pkgs.mali ];
 
       gtk = {
         enable = true;

--- a/planet/modules/home-manager/kitty/default.nix
+++ b/planet/modules/home-manager/kitty/default.nix
@@ -1,7 +1,7 @@
-{ localFlake', ... }:
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 {
@@ -25,7 +25,7 @@
     in
     mkIf cfg.enable (mkMerge [
       {
-        home.packages = [ localFlake'.packages.iosevka-term-custom ];
+        home.packages = [ pkgs.pers-pkgs.iosevka-term-custom ];
         programs.kitty = {
           enable = true;
           settings = {

--- a/planet/modules/home-manager/mako/default.nix
+++ b/planet/modules/home-manager/mako/default.nix
@@ -1,7 +1,7 @@
-{ localFlake', ... }:
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 {
@@ -21,7 +21,7 @@
       inherit (lib) mkIf;
     in
     mkIf cfg.enable {
-      home.packages = [ localFlake'.packages.mali ];
+      home.packages = [ pkgs.pers-pkgs.mali ];
       services.mako = {
         enable = true;
         anchor = "bottom-right";
@@ -34,7 +34,7 @@
         padding = "16";
         borderRadius = 4;
         borderSize = 3;
-        extraConfig = builtins.readFile "${localFlake'.packages.catppuccin-mako}/share/mako/themes/catppuccin/macchiato";
+        extraConfig = builtins.readFile "${pkgs.pers-pkgs.catppuccin-mako}/share/mako/themes/catppuccin/macchiato";
       };
     };
 }

--- a/planet/modules/home-manager/polybar/default.nix
+++ b/planet/modules/home-manager/polybar/default.nix
@@ -1,4 +1,3 @@
-{ localFlake', ... }:
 {
   config,
   lib,
@@ -32,7 +31,7 @@
       };
 
       configFile = pkgs.replaceVars ./config.ini {
-        colors = "${localFlake'.packages.catppuccin-polybar}/share/polybar/themes/catppuccin/macchiato.ini";
+        colors = "${pkgs.pers-pkgs.catppuccin-polybar}/share/polybar/themes/catppuccin/macchiato.ini";
       };
 
       optionalBspwmTarget = lists.optional cfg.bspwmIntegration "bspwm-session.target";

--- a/planet/modules/home-manager/rofi/default.nix
+++ b/planet/modules/home-manager/rofi/default.nix
@@ -1,4 +1,3 @@
-{ localFlake', ... }:
 {
   config,
   lib,
@@ -22,13 +21,13 @@
       inherit (lib) mkIf;
     in
     mkIf cfg.enable {
-      home.packages = [ localFlake'.packages.mali ];
+      home.packages = [ pkgs.pers-pkgs.mali ];
       programs.rofi = {
         enable = true;
         configPath = "${config.xdg.configHome}/rofi/home-manager.rasi";
         font = "Mali 16";
         terminal = "${pkgs.wezterm}/bin/wezterm";
-        theme = "${localFlake'.packages.catppuccin-rofi}/share/rofi/themes/catppuccin-basic/catppuccin-macchiato.rasi";
+        theme = "${pkgs.pers-pkgs.catppuccin-rofi}/share/rofi/themes/catppuccin-basic/catppuccin-macchiato.rasi";
         extraConfig = {
           m = -1;
           steal-focus = true;
@@ -41,7 +40,7 @@
 
       xdg.configFile."rofi/config.rasi".text = ''
         @import "${config.programs.rofi.configPath}"
-        ${builtins.readFile "${localFlake'.packages.catppuccin-rofi}/share/rofi/themes/catppuccin-basic/config.rasi"}
+        ${builtins.readFile "${pkgs.pers-pkgs.catppuccin-rofi}/share/rofi/themes/catppuccin-basic/config.rasi"}
       '';
     };
 }

--- a/planet/modules/home-manager/sioyek/default.nix
+++ b/planet/modules/home-manager/sioyek/default.nix
@@ -1,7 +1,7 @@
-{ localFlake', ... }:
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 {
@@ -47,7 +47,7 @@
       inherit (lib) mkIf;
     in
     mkIf cfg.enable {
-      home.packages = [ localFlake'.packages.iosevka-custom ];
+      home.packages = [ pkgs.pers-pkgs.iosevka-custom ];
       programs.sioyek = {
         enable = true;
         bindings = {

--- a/planet/modules/home-manager/waybar/default.nix
+++ b/planet/modules/home-manager/waybar/default.nix
@@ -1,4 +1,3 @@
-{ localFlake', ... }:
 {
   config,
   lib,
@@ -185,7 +184,7 @@
           };
         };
         style = pkgs.replaceVars ./style.css {
-          themePath = "${localFlake'.packages.catppuccin-waybar}/share/waybar/themes/catppuccin/macchiato.css";
+          themePath = "${pkgs.pers-pkgs.catppuccin-waybar}/share/waybar/themes/catppuccin/macchiato.css";
         };
       };
     };

--- a/planet/modules/home-manager/wezterm/default.nix
+++ b/planet/modules/home-manager/wezterm/default.nix
@@ -1,4 +1,3 @@
-{ localFlake', ... }:
 {
   config,
   lib,
@@ -40,7 +39,7 @@
       {
         home.packages = with pkgs; [
           material-design-icons
-          localFlake'.packages.iosevka-term-custom
+          pkgs.pers-pkgs.iosevka-term-custom
           nerd-fonts.symbols-only
         ];
 

--- a/planet/modules/home-manager/wired/default.nix
+++ b/planet/modules/home-manager/wired/default.nix
@@ -1,6 +1,5 @@
 {
   localFlakeInputs,
-  localFlake',
   localFlakeInputs',
   ...
 }:
@@ -37,7 +36,7 @@
       inherit (lib) mkIf;
     in
     mkIf cfg.enable {
-      home.packages = [ localFlake'.packages.iosevka-custom ];
+      home.packages = [ pkgs.pers-pkgs.iosevka-custom ];
 
       services.wired = {
         enable = true;

--- a/planet/modules/home-manager/wlsunset/default.nix
+++ b/planet/modules/home-manager/wlsunset/default.nix
@@ -1,4 +1,3 @@
-{ localFlake', ... }:
 {
   config,
   lib,
@@ -19,8 +18,8 @@
 
         package = mkOption {
           type = types.package;
-          default = localFlake'.packages.wlsunset;
-          defaultText = "localFlake'.packages.wlsunset";
+          default = pkgs.pers-pkgs.wlsunset;
+          defaultText = "pkgs.pers-pkgs.wlsunset";
           description = ''
             wlsunset derivation to use.
           '';
@@ -140,29 +139,28 @@
           Service = {
             ExecStart =
               let
-                args =
-                  [
-                    "-t"
-                    (toString cfg.temperature.night)
-                    "-T"
-                    (toString cfg.temperature.day)
-                    "-g"
-                    (toString cfg.gamma)
-                  ]
-                  ++ optionals manual [
-                    "-S"
-                    (toString cfg.sunrise)
-                    "-s"
-                    (toString cfg.sunset)
-                    "-d"
-                    (toString cfg.duration)
-                  ]
-                  ++ optionals coords [
-                    "-l"
-                    (toString cfg.latitude)
-                    "-L"
-                    (toString cfg.longitude)
-                  ];
+                args = [
+                  "-t"
+                  (toString cfg.temperature.night)
+                  "-T"
+                  (toString cfg.temperature.day)
+                  "-g"
+                  (toString cfg.gamma)
+                ]
+                ++ optionals manual [
+                  "-S"
+                  (toString cfg.sunrise)
+                  "-s"
+                  (toString cfg.sunset)
+                  "-d"
+                  (toString cfg.duration)
+                ]
+                ++ optionals coords [
+                  "-l"
+                  (toString cfg.latitude)
+                  "-L"
+                  (toString cfg.longitude)
+                ];
               in
               "${cfg.package}/bin/wlsunset ${escapeShellArgs args}";
           };

--- a/planet/modules/home-manager/zathura/default.nix
+++ b/planet/modules/home-manager/zathura/default.nix
@@ -1,7 +1,7 @@
-{ localFlake', ... }:
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 {
@@ -47,7 +47,7 @@
       inherit (lib) mkIf;
     in
     mkIf cfg.enable {
-      home.packages = [ localFlake'.packages.iosevka-custom ];
+      home.packages = [ pkgs.pers-pkgs.iosevka-custom ];
       programs.zathura = {
         enable = true;
         options = {
@@ -56,7 +56,7 @@
           selection-clipboard = "clipboard";
         };
         extraConfig = ''
-          include ${localFlake'.packages.catppuccin-zathura}/share/zathura/themes/catppuccin-macchiato
+          include ${pkgs.pers-pkgs.catppuccin-zathura}/share/zathura/themes/catppuccin-macchiato
         '';
       };
       xdg.mimeApps.defaultApplications = mkIf cfg.defaultApplication.enable (

--- a/planet/modules/nixos/default.nix
+++ b/planet/modules/nixos/default.nix
@@ -12,12 +12,12 @@ _: {
     ./mullvad-vpn
     ./neovim
     ./network-manager
-    (importModule ./nvidia { })
+    ./nvidia
     (importModule ./persistence { })
     (importModule ./pipewire { })
     ./podman
     ./qmk
-    (importModule ./sddm { })
+    ./sddm
     ./steam
     ./tlp
     ./udisks2

--- a/planet/modules/nixos/nvidia/default.nix
+++ b/planet/modules/nixos/nvidia/default.nix
@@ -1,7 +1,7 @@
-{ localFlake', ... }:
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 {
@@ -23,6 +23,6 @@
     mkIf cfg.enable {
       # Required for nvidia prime
       services.xserver.videoDrivers = [ "nvidia" ];
-      environment.systemPackages = [ localFlake'.packages.nvidia-offload ];
+      environment.systemPackages = [ pkgs.pers-pkgs.nvidia-offload ];
     };
 }

--- a/planet/modules/nixos/sddm/default.nix
+++ b/planet/modules/nixos/sddm/default.nix
@@ -1,4 +1,3 @@
-{ localFlake', ... }:
 {
   config,
   lib,
@@ -23,7 +22,7 @@
     in
     mkIf cfg.enable {
       fonts.packages = [
-        localFlake'.packages.iosevka-custom
+        pkgs.pers-pkgs.iosevka-custom
       ];
 
       environment.systemPackages = with pkgs; [


### PR DESCRIPTION
Many of these uses of `importApply` are there to access `pers-pkgs`. However, since we already have access to `pers-pkgs` through an overlay, they are redundant.